### PR TITLE
fix: read-edn macro doesnt exists in cljs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ convenience functions exposed through the `hiposfer.gtfs.edn` namespace.
 ;; fetch the reference gtfs spec first
 ;; ONLY for clojure -> in clojurescript you would need to use the git submodule
 ;; approach. See below
-(def reference (gtfs/reference))
+(def gtfs-spec (gtfs/spec))
 
 ;; fetch all gtfs fields that are required
-(filter :required (gtfs/fields reference))
+(filter :required (gtfs/fields gtfs-spec))
 
 ;; fetch all gtfs fields that represent a dataset unique attribute
-(filter :unique (gtfs/fields reference))
+(filter :unique (gtfs/fields gtfs-spec))
 
 ;; fetch all gtfs fields for the "agency.txt" feed
-(filter #(= "agency.txt" (:filename %)) (gtfs/fields reference))
+(filter #(= "agency.txt" (:filename %)) (gtfs/fields gtfs-spec))
 ```
 
 - as a git submodule

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ dont want to manually recreate it.
 
 # Usage
 
-This project can be used in two ways, dependending on how you wish to use it.
+This project can be used in two ways:
 
 - as a Clojure(script) library
 
@@ -24,14 +24,19 @@ convenience functions exposed through the `hiposfer.gtfs.edn` namespace.
 (ns my.namespace
   (:require [hiposfer.gtfs.edn :as gtfs])) 
 
+;; fetch the reference gtfs spec first
+;; ONLY for clojure -> in clojurescript you would need to use the git submodule
+;; approach. See below
+(def reference (gtfs/reference))
+
 ;; fetch all gtfs fields that are required
-(filter :required gtfs/fields)
+(filter :required (gtfs/fields reference))
 
 ;; fetch all gtfs fields that represent a dataset unique attribute
-(filter :unique gtfs/fields)
+(filter :unique (gtfs/fields reference))
 
 ;; fetch all gtfs fields for the "agency.txt" feed
-(filter #(= "agency.txt" (:filename %)) gtfs/fields)
+(filter #(= "agency.txt" (:filename %)) (gtfs/fields reference))
 ```
 
 - as a git submodule

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/gtfs.edn "0.1.2"
+(defproject hiposfer/gtfs.edn "0.2.0"
   :description "A simple gtfs library that exposes the GTFS spec as edn data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject hiposfer/gtfs.edn "0.2.0-SNAPSHOT3"
+(defproject hiposfer/gtfs.edn "0.2.0-SNAPSHOT4"
   :description "A simple gtfs library that exposes the GTFS spec as edn data"
-  :url "https://github.com/hiposfer/kamal"
+  :url "https://github.com/hiposfer/gtfs.edn"
   :license {:name "LGPLv3"
-            :url "https://github.com/hiposfer/kamal/blob/master/LICENSE"}
+            :url "https://github.com/hiposfer/gtfs.edn/blob/master/LICENSE"}
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
                  [org.clojure/clojurescript "1.9.946" :scope "provided"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/gtfs.edn "0.2.0-SNAPSHOT"
+(defproject hiposfer/gtfs.edn "0.2.0-SNAPSHOT2"
   :description "A simple gtfs library that exposes the GTFS spec as edn data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"
@@ -9,4 +9,5 @@
   :profiles {:dev {:dependencies [[markdown2clj "0.1.3"]]
                    :plugins [[jonase/eastwood "0.2.6"]]}}
   ;; deploy to clojars as - lein deploy releases
-  :deploy-repositories [["releases" {:sign-releases false :url "https://clojars.org/repo"}]])
+  :deploy-repositories [["releases" {:sign-releases false :url "https://clojars.org/repo"}]
+                        ["snapshots" {:sign-releases false :url "https://clojars.org/repo"}]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/gtfs.edn "0.2.0-SNAPSHOT4"
+(defproject hiposfer/gtfs.edn "0.2.0"
   :description "A simple gtfs library that exposes the GTFS spec as edn data"
   :url "https://github.com/hiposfer/gtfs.edn"
   :license {:name "LGPLv3"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/gtfs.edn "0.2.0"
+(defproject hiposfer/gtfs.edn "0.2.0-SNAPSHOT"
   :description "A simple gtfs library that exposes the GTFS spec as edn data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiposfer/gtfs.edn "0.2.0-SNAPSHOT2"
+(defproject hiposfer/gtfs.edn "0.2.0-SNAPSHOT3"
   :description "A simple gtfs library that exposes the GTFS spec as edn data"
   :url "https://github.com/hiposfer/kamal"
   :license {:name "LGPLv3"

--- a/src/hiposfer/gtfs/edn.cljc
+++ b/src/hiposfer/gtfs/edn.cljc
@@ -14,14 +14,14 @@
           nil
           coll))
 
-#?(:clj (defn reference
+#?(:clj (defn spec
           []
           (edn/read-string (clojure.core/slurp (io/resource "reference.edn")))))
 
 (defn identifiers
   "returns a sequence of fields from the gtfs spec that are marked as DATASET UNIQUE"
-  [reference]
-  (for [feed  (:feeds reference)
+  [spec]
+  (for [feed  (:feeds spec)
         field (:fields feed)
         :when (:unique field)]
     field))
@@ -78,9 +78,9 @@
 
   Useful to have a direct mapping between GTFS fields and Clojure fully
   qualified keywords"
-  [reference]
-  (let [dataset-unique (identifiers reference)]
-    (for [feed  (:feeds reference)
+  [spec]
+  (let [dataset-unique (identifiers spec)]
+    (for [feed  (:feeds spec)
           :let [ns-name (feed-namespace feed)]
           field (:fields feed)]
       (let [k (gtfs-mapping dataset-unique ns-name field)]
@@ -90,17 +90,18 @@
   "given a gtfs feed and field name returns its field data from the gtfs/field
 
   A single fully qualified keyword is also accepted as argument"
-  ([reference filename field-name]
+  ([spec filename field-name]
    (reduce (fn [_ v] (when (and (= filename (:filename v))
                                 (= field-name (:field-name v)))
                        (reduced v)))
            nil
-           (fields reference)))
-  ([reference k]
+           (fields spec)))
+  ([spec k]
    (reduce (fn [_ v] (when (= k (:keyword v)) (reduced v)))
            nil
-           (fields reference))))
-;;(get-mapping "agency.txt" "agency_id")
+           (fields spec))))
+
+;;(get-mapping (spec) "agency.txt" "agency_id")
 ;;(get-mapping "trips.txt" "route_id")
 ;;(get-mapping "calendar.txt" "service_id")
 ;;(get-mapping "calendar_dates.txt" "service_id")

--- a/src/hiposfer/gtfs/edn.cljc
+++ b/src/hiposfer/gtfs/edn.cljc
@@ -17,7 +17,7 @@
 
 #?(:clj (defmacro reference
           []
-          `(edn/read-string (slurp (io/resource "reference.edn")))))
+          (edn/read-string (clojure.core/slurp (io/resource "reference.edn")))))
 
 (defn- identifiers
   [reference]

--- a/src/hiposfer/gtfs/edn.cljc
+++ b/src/hiposfer/gtfs/edn.cljc
@@ -1,7 +1,6 @@
 (ns hiposfer.gtfs.edn
   "functionality that creates a mapping between GTFS feed files and clojure
    keywords"
-  #?(:cljs (:require-macros hiposfer.gtfs.edn))
   (:require [clojure.string :as str]
             #?(:clj [clojure.edn :as edn])
             #?(:clj [clojure.java.io :as io])))
@@ -15,7 +14,7 @@
           nil
           coll))
 
-#?(:clj (defmacro reference
+#?(:clj (defn reference
           []
           (edn/read-string (clojure.core/slurp (io/resource "reference.edn")))))
 

--- a/src/hiposfer/gtfs/edn.cljc
+++ b/src/hiposfer/gtfs/edn.cljc
@@ -1,6 +1,7 @@
 (ns hiposfer.gtfs.edn
   "functionality that creates a mapping between GTFS feed files and clojure
    keywords"
+  #?(:cljs (:require-macros hiposfer.gtfs.edn))
   (:require [clojure.string :as str]
             #?(:clj [clojure.edn :as edn])
             #?(:clj [clojure.java.io :as io])))


### PR DESCRIPTION
It turns out I was wrong and the changes from the latest PR (#5 ) were not enough to make it work in Clojurescript.

Clojurescript doesnt expose any file-reading functionality since it depends on the target platform; browser, nodejs, etc. See [discussion](https://groups.google.com/forum/#!topic/clojurescript/zfnK8Wxg-bM)

So this PR changes the way in which we used the functions here and pushes the file read task to the user. Basically "figure out how to read files on your own", then you can use these functions.

For Clojure users, we still provide the read-file functionality for convenience.
